### PR TITLE
Upgrade/optimize stopping muon selection

### DIFF
--- a/h5flow_data/README.md
+++ b/h5flow_data/README.md
@@ -1,0 +1,7 @@
+# H5Flow data directory
+
+This directory is used as a central location for inputs to the Module 0
+workflows.
+
+By running the tests, this directory will automatically fill with the necessary
+files for running the basic workflows.

--- a/h5flow_modules/analysis/stopping_muon_selection.py
+++ b/h5flow_modules/analysis/stopping_muon_selection.py
@@ -31,28 +31,33 @@ class StoppingMuonSelection(H5FlowStage):
 
 
     '''
-    class_version = '1.1.0'
+    class_version = '2.0.0'
 
-    default_fid_cut = 20  # mm
-    default_cathode_fid_cut = 20  # mm
-    default_length_cut = 100  # mm
-    default_profile_dx = 20  # mm
-    default_profile_max_range = 1600  # mm
-    default_larpix_gain = 250  # e/mV
-    default_larpix_noise = 500  # e/mm
-    default_proton_classifier_cut = 0.1565
-    default_muon_classifier_cut = 0.2424
-    default_dqdx_peak_cut = 12e3  # e/mm
-    default_profile_search_dx = 50  # mm
-    default_remaining_e_cut = 85e3  # keV
-    default_curvature_rr_correction = 22.6647 / 22
-    default_density_dx_correction_params = [0.78497819, -3.41826874, 198.93022888]
-    default_hits_dset_name = 'charge/hits'
-    default_merged_dset_name = 'combined/tracklets/merged'
-    default_t0_dset_name = 'combined/t0'
-    default_hit_drift_dset_name = 'combined/hit_drift'
-    default_truth_trajectories_dset_name = 'mc_truth/trajectories'
-    default_path = 'analysis/stopping_muons'
+    defaults = dict(
+        fid_cut=30, # mm
+        cathode_fid_cut=20, # mm
+        anode_fid_cut=30, # mm
+        projected_length_cut=20, # mm
+        veto_charge_cut=100e3, # e-
+        profile_dx=22, # mm
+        profile_max_range=1600, # mm
+        larpix_gain=250, # e/mV
+        larpix_noise=500,  # e/mm
+        proton_classifier_cut=0.1565,
+        muon_classifier_cut=0.2424,
+        dqdx_peak_cut=12e3, # e/mm
+        profile_search_dx=50, # mm
+        remaining_e_cut=85e3, # keV
+
+        curvature_rr_correction=22.6647 / 22,
+        density_dx_correction_params=[0.78497819, -3.41826874, 198.93022888],
+
+        hits_dset_name='charge/hits',
+        merged_dset_name='combined/tracklets/merged',
+        t0_dset_name='combined/t0',
+        hit_drift_dset_name='combined/hit_drift',
+        truth_trajectories_dset_name='mc_truth/trajectories',
+        path='analysis/stopping_muons')
 
     event_sel_dset_name = 'event_sel_reco'
     event_profile_dset_name = 'event_profile'
@@ -86,35 +91,12 @@ class StoppingMuonSelection(H5FlowStage):
     def __init__(self, **params):
         super(StoppingMuonSelection, self).__init__(**params)
 
-        self.path = params.get('path', self.default_path)
-        self.fid_cut = params.get('fid_cut', self.default_fid_cut)
-        self.cathode_fid_cut = params.get('cathode_fid_cut', self.default_cathode_fid_cut)
-        self.length_cut = params.get('length_cut', self.default_length_cut)
-        self.larpix_noise = params.get('larpix_noise', self.default_larpix_noise)
-        self.dqdx_peak_cut = params.get('dqdx_peak_cut', self.default_dqdx_peak_cut)
-        self.proton_classifier_cut = params.get('proton_classifier_cut', self.default_proton_classifier_cut)
-        self.muon_classifier_cut = params.get('muon_classifier_cut', self.default_muon_classifier_cut)
-        self.remaining_e_cut = params.get('remaining_e_cut', self.default_remaining_e_cut)
-        self.profile_dx = params.get('profile_dx', self.default_profile_dx)
-        self.profile_search_dx = params.get('profile_search_dx', self.default_profile_search_dx)
-        self.profile_max_range = params.get('profile_max_range',
-                                            self.default_profile_max_range)
+        for key,val in self.defaults.items():
+            setattr(self, key, params.get(key, val))
+
         self.curvature_rr_correction = params.get('curvature_rr_correction', dict())
         self.density_dx_correction_params = params.get('density_dx_correction_params', dict())
         self.larpix_gain = params.get('larpix_gain', dict())
-
-        self.hits_dset_name = params.get('hits_dset_name',
-                                         self.default_hits_dset_name)
-        self.t0_dset_name = params.get('t0_dset_name',
-                                       self.default_t0_dset_name)
-        self.hit_drift_dset_name = params.get('hit_drift_dset_name',
-                                              self.default_hit_drift_dset_name)
-        self.truth_trajectories_dset_name = params.get('truth_trajectories_dset_name',
-                                                       self.default_truth_trajectories_dset_name)
-        self.hits_dset_name = params.get('hits_dset_name',
-                                         self.default_hits_dset_name)
-        self.merged_dset_name = params.get('merged_dset_name',
-                                           self.default_merged_dset_name)
 
         self.event_profile_dtype = self.event_profile_dtype(self.profile_dx,
                                                             self.profile_max_range)
@@ -132,26 +114,13 @@ class StoppingMuonSelection(H5FlowStage):
         self.density_dx_correction_params = self.density_dx_correction_params.get(correction_key, self.default_density_dx_correction_params)
         self.larpix_gain = self.larpix_gain.get(correction_key, self.default_larpix_gain)
 
+        attrs = dict()
+        for key in self.defaults:
+            attrs[key] = getattr(self, key)
         self.data_manager.set_attrs(self.path,
                                     classname=self.classname,
                                     class_version=self.class_version,
-                                    fid_cut=self.fid_cut,
-                                    length_cut=self.length_cut,
-                                    profile_dx=self.profile_dx,
-                                    dqdx_peak_cut=self.dqdx_peak_cut,
-                                    proton_classifier_cut=self.proton_classifier_cut,
-                                    muon_classifier_cut=self.muon_classifier_cut,
-                                    remaining_e_cut=self.remaining_e_cut,
-                                    profile_search_dx=self.profile_search_dx,
-                                    profile_max_range=self.profile_max_range,
-                                    curvature_rr_correction=self.curvature_rr_correction,
-                                    density_dx_correction_params=self.density_dx_correction_params,
-                                    hits_dset_name=self.hits_dset_name,
-                                    t0_dset_name=self.t0_dset_name,
-                                    hit_drift_dset_name=self.hit_drift_dset_name,
-                                    merged_dset_name=self.merged_dset_name,
-                                    truth_trajectories_dset_name=self.truth_trajectories_dset_name,
-                                    )
+                                    **attrs)
         self.data_manager.create_dset(f'{self.path}/{self.event_sel_dset_name}',
                                       self.event_sel_dtype)
         self.data_manager.create_dset(f'{self.path}/{self.event_profile_dset_name}',
@@ -318,9 +287,9 @@ class StoppingMuonSelection(H5FlowStage):
 
         '''
         start_in_fid = resources['Geometry'].in_fid(
-            start_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            start_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         end_in_fid = resources['Geometry'].in_fid(
-            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         track_stopping = (~start_in_fid & end_in_fid) | (start_in_fid & ~end_in_fid)
         return track_stopping
 
@@ -334,9 +303,9 @@ class StoppingMuonSelection(H5FlowStage):
 
         '''
         start_in_fid = resources['Geometry'].in_fid(
-            start_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            start_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         end_in_fid = resources['Geometry'].in_fid(
-            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         track_through_going = ~start_in_fid & ~end_in_fid
         return track_through_going
 
@@ -350,7 +319,7 @@ class StoppingMuonSelection(H5FlowStage):
 
         '''
         end_in_fid = resources['Geometry'].in_fid(
-            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            end_xyz, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         dy = end_xyz[:, 1] - start_xyz[:, 1]
         return ((end_in_fid & (dy < 0)) | (~end_in_fid & (dy > 0)))
 
@@ -790,8 +759,7 @@ class StoppingMuonSelection(H5FlowStage):
         track_start = tracks.ravel()['trajectory'][..., 0, :]
         track_stop = tracks.ravel()['trajectory'][..., -1, :]
         track_length = tracks.ravel()['length']
-        is_stopping = (self.stopping(track_start, track_stop)  # track enters and stops
-                       & (track_length > self.length_cut))  # track is reasonably long
+        is_stopping = self.stopping(track_start, track_stop)  # track enters and stops
 
         is_throughgoing = self.through_going(track_start, track_stop)
         is_downward = self.downward(track_start, track_stop)
@@ -830,22 +798,34 @@ class StoppingMuonSelection(H5FlowStage):
                 true_xyz_start = track_true_traj['xyz_start']
                 true_xyz_end = track_true_traj['xyz_end']
 
-        # define a stopping event as one with exclusively 1 track that ends in fid.
+        # define a stopping event as one with exclusively 1 track that enters from the outer boundary,
+        # going downward, with little activity in the outer veto region and no through-going tracks
         start_in_fid = resources['Geometry'].in_fid(
-            track_start, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            track_start, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         seed_pt = np.where(np.expand_dims(start_in_fid, axis=-1),
                            track_stop, track_start).reshape(tracks.shape + (3,))
-        seed_pt = np.take_along_axis(seed_pt, np.argmax(is_stopping, axis=-1)[..., np.newaxis, np.newaxis],
-                                     axis=-2)
+        seed_near_cathode = (resources['Geometry'].in_fid(
+                seed_pt, cathode_fid=0, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
+            & ~resources['Geometry'].in_fid(
+                seed_pt, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut))
+        seed_near_cathode = seed_near_cathode.reshape(tracks.shape)
+        seed_track_mask = is_stopping & ~seed_near_cathode & is_downward
+        seed_pt = np.take_along_axis(seed_pt, np.argmax(seed_track_mask, axis=-1)[..., np.newaxis, np.newaxis], axis=-2)
+
         hit_in_fid = resources['Geometry'].in_fid(
-            hit_xyz.reshape(-1, 3), cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut).reshape(hit_xyz.shape[:-1])
-        hits_not_in_fid = np.any((~hit_in_fid & ~hits['id'].mask
-                                  & (np.sum((hit_xyz - seed_pt)**2, axis=-1) > self.profile_search_dx**2)), axis=-1)
-        event_is_stopping = ((ma.sum(is_stopping, axis=-1) == 1)
-                             & (t0['type'] != 0)
-                             & ~hits_not_in_fid
+            hit_xyz.reshape(-1, 3), cathode_fid=0, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut).reshape(hit_xyz.shape[:-1])
+        hit_in_veto = (~hit_in_fid & ~hits.mask['id'] & (np.sum((hit_xyz - seed_pt)**2, axis=-1) > 25*stopping_muon_selection.profile_search_dx**2))
+        veto_q = np.sum(hits['q'] * self.larpix_gain * hit_in_veto, axis=-1)
+
+        active_proj_length = self.extrapolated_intersection(tracks.ravel()['trajectory'][..., -2, :], tracks.ravel()['trajectory'][..., -1, :])
+        active_proj_length = active_proj_length.reshape(tracks.shape)
+        active_proj_length = np.take_along_axis(active_proj_length, np.argmax(seed_track_mask, axis=-1)[...,np.newaxis], axis=-1).reshape(events.shape)
+        
+        event_is_stopping = ((t0['type'] != 0)
+                             & (veto_q < self.veto_charge_cut)
+                             & (active_proj_length > self.projected_length_cut)
                              & (ma.sum(is_throughgoing, axis=-1) == 0)
-                             & (ma.sum(is_stopping & is_downward, axis=-1) == 1))
+                             & (ma.sum(seed_track_mask, axis=-1) == 1))
 
         # now check the likelihood of a stopping muon
         # first generated the dQ/dx profile
@@ -934,7 +914,7 @@ class StoppingMuonSelection(H5FlowStage):
 
         # check if endpoint in fiducial volume
         end_pt_in_fid = resources['Geometry'].in_fid(
-            end_pt.reshape(-1, 3), cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+            end_pt.reshape(-1, 3), cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         end_pt_in_fid = end_pt_in_fid.reshape(tracks.shape[0])
 
         # calculate "additional" energy (all energy not associated to the parent muon) assuming nominal michel dE/dx
@@ -968,7 +948,7 @@ class StoppingMuonSelection(H5FlowStage):
             # define true stopping events as events with at least 1 muon that ends in fid.
             event_is_true_stopping = is_muon & is_true_stopping
             true_xyz_start_in_fid = resources['Geometry'].in_fid(
-                true_xyz_start, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut)
+                true_xyz_start, cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
             true_stop_pt = np.where(np.expand_dims(true_xyz_start_in_fid, axis=-1),
                                     true_xyz_start, true_xyz_end).reshape((-1, 3))
 

--- a/h5flow_yamls/analysis/stopping_muons.yaml
+++ b/h5flow_yamls/analysis/stopping_muons.yaml
@@ -4,6 +4,7 @@ flow:
   source: events
   stages: [truth_labels, stopping_muon_sel]
 
+
 resources:
   - !include h5flow_yamls/resources/run_data.yaml
   - !include h5flow_yamls/resources/lar_data.yaml
@@ -11,11 +12,13 @@ resources:
   - !include h5flow_yamls/resources/particle_data.yaml
   - !include h5flow_yamls/resources/disabled_channels.yaml
 
+
 events:
   classname: H5FlowDatasetLoopGenerator
   dset_name: 'charge/events'
   params:
     chunk_size: 32
+
 
 truth_labels:
   classname: MuonCaptureTruthLabels # analysis/muon_capture_truth_labels.py
@@ -28,9 +31,13 @@ truth_labels:
       path: ['charge/raw_events', 'mc_truth/events', 'mc_truth/trajectories', 'mc_truth/tracks']
       index_only: True
   params:
+    # inputs
     truth_trajectories_dset_name: 'mc_truth/trajectories'
     truth_tracks_dset_name: 'mc_truth/tracks'
+
+    # output
     truth_labels_dset_name: 'analysis/muon_capture/truth_labels'
+
 
 stopping_muon_sel:
   classname: StoppingMuonSelection # analysis/stopping_muon_selection.py
@@ -43,13 +50,14 @@ stopping_muon_sel:
     - name: 'mc_truth/trajectories'
       path: ['charge/raw_events', 'mc_truth/events', 'mc_truth/trajectories']
   params:
+    # inputs
     hits_dset_name: 'charge/hits'
     hit_drift_dset_name: 'combined/hit_drift'    
     t0_dset_name: 'combined/t0'
     merged_dset_name: 'combined/tracklets/merged'
     truth_trajectories_dset_name: 'mc_truth/trajectories'
-    fid_cut: 20 # mm
-    cathode_fid_cut: 20 # mm
+
+    # configuration parameters
     profile_dx: 22 # mm
     larpix_gain:
       mc: 250 # e/mV

--- a/h5flow_yamls/reco/charge/charge_event_reconstruction.yaml
+++ b/h5flow_yamls/reco/charge/charge_event_reconstruction.yaml
@@ -74,9 +74,9 @@ hit_builder:
     hits_dset_name: 'charge/hits'
 
     # configuration parameters
-    pedestal_file: 'datalog_2021_04_02_19_00_46_CESTevd_ped.json'
+    pedestal_file: 'h5flow_data/datalog_2021_04_02_19_00_46_CESTevd_ped.json'
     # download link: https://portal.nersc.gov/project/dune/data/Module0/TPC1+2/configFiles/datalog_2021_04_02_19_00_46_CESTevd_ped.json
-    configuration_file: 'evd_config_21-03-31_12-36-13.json'
+    configuration_file: 'h5flow_data/evd_config_21-03-31_12-36-13.json'
     # download link: https://portal.nersc.gov/project/dune/data/Module0/TPC1+2/configFiles/evd_config_21-03-31_12-36-13.json
 
 

--- a/h5flow_yamls/reco/combined/combined_reconstruction.yaml
+++ b/h5flow_yamls/reco/combined/combined_reconstruction.yaml
@@ -63,7 +63,7 @@ tracklet_reco:
     ransac_min_samples: 2
     ransac_residual_threshold: 8
     ransac_max_trials: 10
-    trajectory_pts: 8
+    trajectory_pts: 16 #8
 
 
 tracklet_merge:

--- a/h5flow_yamls/reco/combined/combined_reconstruction.yaml
+++ b/h5flow_yamls/reco/combined/combined_reconstruction.yaml
@@ -85,7 +85,7 @@ tracklet_merge:
     merged_dset_name: 'combined/tracklets/merged'
 
     # configuration parameters
-    pdf_filename: 'joint_pdf-2_0_1.npz'
+    pdf_filename: 'h5flow_data/joint_pdf-2_0_1.npz'
     # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/joint_pdf-2_0_1.npz
     pvalue_cut: 0.05
     max_neighbors: 5

--- a/h5flow_yamls/reco/light/light_event_reconstruction.yaml
+++ b/h5flow_yamls/reco/light/light_event_reconstruction.yaml
@@ -67,11 +67,11 @@ wvfm_deconv:
       16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 35,
       36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
       54, 55, 56, 57, 58, 59, 60, 61, 62, 63 ]
-    noise_spectrum_filename: 'rwf_20210624_094156.fwvfm.noise_power.npz'
+    noise_spectrum_filename: 'h5flow_data/rwf_20210624_094156.fwvfm.noise_power.npz'
     # download link: https://portal.nersc.gov/project/dune/data/Module0-Run2/LRS/LED/rwf_20210624_094156.fwvfm.noise_power.npz
-    signal_spectrum_filename: 'wvfm_deconv_signal_power.npz'
+    signal_spectrum_filename: 'h5flow_data/wvfm_deconv_signal_power.npz'
     # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/prod2/light_noise_filtered/wvfm_deconv_signal_power.npz
-    signal_impulse_filename: 'wvfm_deconv_signal_impulse.fit.npz'
+    signal_impulse_filename: 'h5flow_data/wvfm_deconv_signal_impulse.fit.npz'
     # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/prod2/light_noise_filtered/wvfm_deconv_signal_impulse.fit.npz
 
 

--- a/h5flow_yamls/reco/light/light_wvfm_filtering.yaml
+++ b/h5flow_yamls/reco/light/light_wvfm_filtering.yaml
@@ -33,9 +33,9 @@ wvfm_deconv_inverse:
     filter_type: Inverse
     gaus_filter_width: 1
     filter_channels: [ 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 ] # apply filtering to these channels
-    noise_spectrum_filename: 'rwf_20210624_094156.fwvfm.noise_power.npz'
-    signal_spectrum_filename: 'wvfm_deconv_signal_power.npz'
-    signal_impulse_filename: 'wvfm_deconv_signal_impulse.fit.npz'
+    noise_spectrum_filename: 'h5flow_data/rwf_20210624_094156.fwvfm.noise_power.npz'
+    signal_spectrum_filename: 'h5flow_data/wvfm_deconv_signal_power.npz'
+    signal_impulse_filename: 'h5flow_data/wvfm_deconv_signal_impulse.fit.npz'
     # see light_event_reconstruction.yaml for download links
 
 wvfm_deconv_wiener:
@@ -49,9 +49,9 @@ wvfm_deconv_wiener:
     filter_type: Wiener
     gaus_filter_width: 1
     filter_channels: [ 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 ] # apply filtering to these channels
-    noise_spectrum_filename: 'rwf_20210624_094156.fwvfm.noise_power.npz'
-    signal_spectrum_filename: 'wvfm_deconv_signal_power.npz'
-    signal_impulse_filename: 'wvfm_deconv_signal_impulse.fit.npz'
+    noise_spectrum_filename: 'h5flow_data/rwf_20210624_094156.fwvfm.noise_power.npz'
+    signal_spectrum_filename: 'h5flow_data/wvfm_deconv_signal_power.npz'
+    signal_impulse_filename: 'h5flow_data/wvfm_deconv_signal_impulse.fit.npz'
     # see light_event_reconstruction.yaml for download links
 
 wvfm_deconv_matched:
@@ -65,7 +65,7 @@ wvfm_deconv_matched:
     filter_type: Matched
     gaus_filter_width: 1
     filter_channels: [ 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 ] # apply filtering to these channels
-    noise_spectrum_filename: 'rwf_20210624_094156.fwvfm.noise_power.npz'
-    signal_spectrum_filename: 'wvfm_deconv_signal_power.npz'
-    signal_impulse_filename: 'wvfm_deconv_signal_impulse.fit.npz'
+    noise_spectrum_filename: 'h5flow_data/rwf_20210624_094156.fwvfm.noise_power.npz'
+    signal_spectrum_filename: 'h5flow_data/wvfm_deconv_signal_power.npz'
+    signal_impulse_filename: 'h5flow_data/wvfm_deconv_signal_impulse.fit.npz'
     # see light_event_reconstruction.yaml for download links

--- a/h5flow_yamls/resources/disabled_channels.yaml
+++ b/h5flow_yamls/resources/disabled_channels.yaml
@@ -1,7 +1,7 @@
 classname: DisabledChannels # resources/disabled_channels.py
 params:
   path: 'disabled_channels'
-  disabled_channels_list: 'module0-run1-selftrigger-disabled-list.json'
+  disabled_channels_list: 'h5flow_data/module0-run1-selftrigger-disabled-list.json'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/TPC1+2/badChannelLists/selftrigger_masked/module0-run1-selftrigger-disabled-list.json
-  missing_asic_list: 'module0-network-absent-ASICs.json'
+  missing_asic_list: 'h5flow_data/module0-network-absent-ASICs.json'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/TPC1+2/badChannelLists/module0-network-absent-ASICs.json

--- a/h5flow_yamls/resources/geometry.yaml
+++ b/h5flow_yamls/resources/geometry.yaml
@@ -1,5 +1,5 @@
 classname: Geometry # resources/geometry.py
 params:
   path: 'geometry_info'
-  crs_geometry_file: 'multi_tile_layout-2.2.16.yaml'
+  crs_geometry_file: 'h5flow_data/multi_tile_layout-2.2.16.yaml'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/multi_tile_layout-2.2.16.yaml

--- a/h5flow_yamls/resources/lar_data.yaml
+++ b/h5flow_yamls/resources/lar_data.yaml
@@ -1,6 +1,6 @@
 classname: LArData # resources/lar_data.py
 params:
   path: 'lar_info'
-  electron_lifetime_file: 'ElecLifetimeFit_Module0.root'
+  electron_lifetime_file: 'h5flow_data/ElecLifetimeFit_Module0.root'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/electronLifetime/ElecLifetimeFit_Module0.root
   electron_lifetime: 2200 # us

--- a/h5flow_yamls/resources/particle_data.yaml
+++ b/h5flow_yamls/resources/particle_data.yaml
@@ -1,7 +1,7 @@
 classname: ParticleData # resources/particle_data.py
 params:
   path: 'particle_info'
-  muon_range_table_path: 'PDG_muon_range_table_Ar.txt'
+  muon_range_table_path: 'h5flow_data/PDG_muon_range_table_Ar.txt'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/PDG_muon_range_table_Ar.txt
-  proton_range_table_path: 'NIST_proton_range_table_Ar.txt'
+  proton_range_table_path: 'h5flow_data/NIST_proton_range_table_Ar.txt'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/NIST_proton_range_table_Ar.txt

--- a/h5flow_yamls/resources/run_data.yaml
+++ b/h5flow_yamls/resources/run_data.yaml
@@ -1,7 +1,7 @@
 classname: RunData # resources/run_data.py
 params:
   path: 'run_info'
-  runlist_file: 'runlist.txt'
+  runlist_file: 'h5flow_data/runlist.txt'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/runlist.txt
   defaults:
     charge_filename: '-'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,32 +25,30 @@ def maybe_fetch_from_url(pytestconfig, tmp_path_factory, url):
     except FileExistsError:
         dest = os.path.join(tmp_path_factory.getbasetemp(), 'module0_flow')
 
+    cached_filepath = os.path.join(dest, file)
+    src_filepath = os.path.join(src, file)
+    dest_filepath = os.path.join('./h5flow_data/', file)
+
     # check if file exists in current cache
-    if not os.path.exists(os.path.join(dest, file)):
-        if src is None or not os.path.exists(os.path.join(src, file)):
+    if not os.path.exists(cached_filepath):
+        if src is None or not os.path.exists(src_filepath):
             # copy from url
             print(f'Downloading {file} from {url}...')
-            subprocess.run(['curl', '-f', '-o', os.path.join(dest, file), url],
-                           check=True)
+            subprocess.run(['curl', '-f', '-o', cached_filepath, url], check=True)
         else:
             # copy from old cache
-            print(f'Copying {file} from existing cache '
-                  f'{os.path.join(src, file)}...')
-            shutil.copy(os.path.join(src, file), os.path.join(dest, file))
-        print(f'Saved to current cache @ {os.path.join(dest, file)}')
-
+            print(f'Copying {file} from existing cache {src_filepath}...')
+            shutil.copy(os.path.join(src, file), cached_filepath)
+        print(f'Saved to current cache @ {cached_filepath}')
         pytestconfig.cache.set(f'cached_{url}', str(dest))
 
-    # copy file from current cache to cwd
-    if os.path.exists(file):
-        os.remove(file)
-    shutil.copy(os.path.join(dest, file), './')
+    # copy file from current cache to current h5flow data directory
+    if os.path.exists(dest_filepath):
+        print(f'Overwriting {dest_filepath}...')
+        os.remove(dest_filepath)
+    shutil.copy(cached_filepath, dest_filepath)
 
-    yield file
-
-    # cleanup
-    if os.path.exists(file):
-        os.remove(file)
+    yield dest_filepath
 
 
 @pytest.fixture(params=[


### PR DESCRIPTION
Minor modifications to stopping muon selection to optimize selection efficiency - improved efficiency on data by x6-7.
 - Do no cut events with hits near cathode
 - Use hit charge as veto instead of n hit > 0
 - Increase hit veto protection radius to 5x profile search radius around seed point
 - Do not use length cut on tracks used for seed
 - Cut on projected length to exit point that crosses active pixels

Also include new data management scheme (PR #32)