### PR TITLE
Upgrade/improve michel

### DIFF
--- a/h5flow_yamls/workflows/analysis/stopping_muons.yaml
+++ b/h5flow_yamls/workflows/analysis/stopping_muons.yaml
@@ -61,6 +61,9 @@ stopping_muon_sel:
     fid_cut: 20 # mm
     cathode_fid_cut: 20 # mm
 
+    proton_classifier_cut: 0.2576
+    muon_classifier_cut: -0.0152
+
     profile_dx: 22 # mm
     larpix_gain:
       mc: 250 # e/mV
@@ -71,8 +74,8 @@ stopping_muon_sel:
       medm: 1.0
       high: 1.0
     density_dx_correction_params:
-      medm: [  1.32677493,   1.34213283, 119.1455561 ]
-      mc:   [  1.00982736,   1.2525887,  130.32791666]
+      medm: [  1.28,   1.41, 85.9 ]
+      mc:   [  1.06,   1.24, 112  ]
       high: [1.06938198,  1.52281043, 122.37072575]
 
 michel_id:
@@ -85,6 +88,9 @@ michel_id:
       path: ['charge/hits', 'analysis/stopping_muons/hit_profile']
   params:
     # configuration parameters
+    michel_e_cut: 4000 # keV
+    michel_nhit_cut: 7
+
     generate_likelihood_pdf: False
     #generate_likelihood_pdf: True
     likelihood_pdf_filename: h5flow_data/michel_pdf-0.1.0.npz

--- a/h5flow_yamls/workflows/analysis/stopping_muons.yaml
+++ b/h5flow_yamls/workflows/analysis/stopping_muons.yaml
@@ -67,14 +67,13 @@ stopping_muon_sel:
       medm: 221 # e/mV
       high: 221 # e/mV
     curvature_rr_correction:
-      mc: 1.0173259837
-      medm: 1.0143151891
-      high: 1.030
+      mc: 1.0
+      medm: 1.0
+      high: 1.0
     density_dx_correction_params:
-      #mc: [1.13515744, -2.6721365,  47.73539495]
-      medm: [1.75457167,  -3.51691849, 109.78693745]
-      mc:   [1.54540381,  -3.53689009, 133.36754227]
-      high: [1.73174021, -3.62691494, 25.45025883]
+      medm: [1.06938198,  1.52281043, 122.37072575]
+      mc:   [0.90327591,  1.32293714, 182.45456797]
+      high: [1.06938198,  1.52281043, 122.37072575]
 
 michel_id:
   classname: MichelID
@@ -86,5 +85,6 @@ michel_id:
       path: ['charge/hits', 'analysis/stopping_muons/hit_profile_id']
   params:
     # configuration parameters
-    generate_likelihood_pdf: False #True
+    generate_likelihood_pdf: False
+    #generate_likelihood_pdf: True
     likelihood_pdf_filename: h5flow_data/michel_pdf-0.1.0.npz

--- a/h5flow_yamls/workflows/analysis/stopping_muons.yaml
+++ b/h5flow_yamls/workflows/analysis/stopping_muons.yaml
@@ -71,8 +71,8 @@ stopping_muon_sel:
       medm: 1.0
       high: 1.0
     density_dx_correction_params:
-      medm: [1.06938198,  1.52281043, 122.37072575]
-      mc:   [0.90327591,  1.32293714, 182.45456797]
+      medm: [  1.32677493,   1.34213283, 119.1455561 ]
+      mc:   [  1.00982736,   1.2525887,  130.32791666]
       high: [1.06938198,  1.52281043, 122.37072575]
 
 michel_id:
@@ -81,8 +81,8 @@ michel_id:
     - 'charge/hits'
     - name: 'combined/hit_drift'
       path: ['charge/hits', 'combined/hit_drift']
-    - name: 'analysis/stopping_muons/hit_profile_id'
-      path: ['charge/hits', 'analysis/stopping_muons/hit_profile_id']
+    - name: 'analysis/stopping_muons/hit_profile'
+      path: ['charge/hits', 'analysis/stopping_muons/hit_profile']
   params:
     # configuration parameters
     generate_likelihood_pdf: False

--- a/module0_flow/analysis/michel_id.py
+++ b/module0_flow/analysis/michel_id.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.ma as ma
+import scipy.ndimage as ndimage
 
 from h5flow import H5FLOW_MPI
 from h5flow.core import H5FlowStage, resources
@@ -8,7 +9,11 @@ from module0_flow.util import units
 
 
 def load_likelihood_pdf(filename):
-    pdf = np.load(filename).copy()
+    d = np.load(filename)
+    pdf = dict()
+    for key in d.keys():
+        pdf[key] = d[key]
+        pdf[key] = ndimage.gaussian_filter(pdf[key], sigma=0.5)
     pdf['sig'] /= pdf['sig'].sum()
     pdf['bkg'] /= pdf['bkg'].sum()
     return pdf
@@ -20,10 +25,10 @@ def fill_likelihood_pdf(cos_mu, cos_e, d, sig_label, pdf_sig, pdf_bkg,
         [np.expand_dims(cos_mu.ravel(), -1), np.expand_dims(cos_e.ravel(), -1),
          np.expand_dims(d.ravel(), -1)], axis=-1)
 
-    pdf_sig += np.histogramdd(v[sig_label.ravel()], (cos_mu_bins, cos_e_bins, d_bins))[0]
-    pdf_bkg += np.histogramdd(v[~sig_label.ravel()], (cos_mu_bins, cos_e_bins, d_bins))[0]
+    sig = pdf_sig + np.histogramdd(v[sig_label], (cos_mu_bins, cos_e_bins, d_bins))[0]
+    bkg = pdf_bkg + np.histogramdd(v[~sig_label], (cos_mu_bins, cos_e_bins, d_bins))[0]
 
-    return pdf_sig, pdf_bkg
+    return sig, bkg
 
 
 def michel_likelihood_score(cos_mu, cos_e, d, pdf_sig, pdf_bkg,
@@ -47,7 +52,7 @@ def michel_likelihood_score(cos_mu, cos_e, d, pdf_sig, pdf_bkg,
 
 
 class MichelID(H5FlowStage):
-    class_version = '0.0.0'
+    class_version = '0.1.0'
 
     defaults = dict(
         hits_dset_name='charge/hits',
@@ -59,7 +64,7 @@ class MichelID(H5FlowStage):
         hit_label_dset_name='analysis/michel_id/hit_michel_label',
         michel_label_dset_name='analysis/michel_id/michel_label',
 
-        michel_e_cut=10 * units.MeV,
+        michel_e_cut=5 * units.MeV,
         michel_nhit_cut=5,
 
         likelihood_pdf_filename='michel_pdf-{version}.npz',
@@ -70,14 +75,17 @@ class MichelID(H5FlowStage):
         ('michel_flag', 'u1'),
         ('michel_nhit', 'i4'),
         ('michel_e', 'f8'),
+        ('michel_tagged_e', 'f8'),
         ('michel_dir', 'f8', (3,)),
         ('muon_dir', 'f8', (3,)),
-        ('stop_pt', 'f8', (3,))
+        ('stop_pt', 'f8', (3,)),
+        ('michel_end', 'f8', (3,))
     ])
 
     hit_label_dtype = np.dtype([
         ('score', 'f8'),
-        ('michel_flag', 'u1')
+        ('michel_flag', 'u1'),
+        ('muon_flag', 'u1')
     ])
 
     likelihood_bins = (np.linspace(-1, 1, 50), np.linspace(-1, 1, 50), np.geomspace(0.1, 1000, 50))
@@ -91,6 +99,10 @@ class MichelID(H5FlowStage):
 
     def init(self, source_name):
         super(MichelID, self).init(source_name)
+
+        self.larpix_gain = self.data_manager.get_attrs('/'.join(self.stopping_sel_dset_name.split('/')[:-1]))['larpix_gain']
+        michel_dedx = resources['ParticleData'].landau_peak(50 * units.MeV, resources['ParticleData'].e_mass, resources['Geometry'].pixel_pitch)
+        self.recomb_factor = 1 / resources['LArData'].ionization_recombination(michel_dedx)
 
         # load likelihood function
         if not self.generate_likelihood_pdf:
@@ -133,100 +145,130 @@ class MichelID(H5FlowStage):
     def run(self, source_name, source_slice, cache):
         super(MichelID, self).run(source_name, source_slice, cache)
         ev = cache[source_name]
-
-        # load hit xyz positions
         hits = cache[self.hits_dset_name]
-        hit_drift = cache[self.drift_dset_name].reshape(hits.shape)
-        hit_prof_idx = cache[self.hit_prof_idx_dset_name].reshape(hits.shape)
-        hit_xyz = np.concatenate([
-            np.expand_dims(hits['px'], -1), np.expand_dims(hits['py'], -1),
-            np.expand_dims(hit_drift['z'], -1)], axis=-1)
 
-        # load dQ/dx profile and stopping event selection
-        stopping_sel = self.data_manager[self.stopping_sel_dset_name, source_slice].reshape(ev.shape)
-        prof = self.data_manager[self.profile_dset_name, source_slice].reshape(ev.shape)
+        if len(ev):
+            # load hit xyz positions
+            hit_drift = cache[self.drift_dset_name].reshape(hits.shape)
+            hit_prof_idx = cache[self.hit_prof_idx_dset_name].reshape(hits.shape)
+            hit_xyz = np.concatenate([
+                np.expand_dims(hits['px'], -1), np.expand_dims(hits['py'], -1),
+                np.expand_dims(hit_drift['z'], -1)], axis=-1)
 
-        # find start and end points
-        mu_start = np.take_along_axis(
-            prof['profile_pos'], np.expand_dims(np.argmax(prof['profile_n'] > 0, axis=-1), (1, 2)), axis=1)
-        mu_end = stopping_sel['stop_pt'] - stopping_sel['stop_pt_corr']
-        gap_mask = (prof['profile_rr'] < 0) & (prof['profile_n'] > 0)
-        gap_mask[:-1] = gap_mask[:-1] & (prof['profile_n'][1:] == 0)
-        michel_end = np.take_along_axis(
-            prof['profile_pos'], np.expand_dims(np.argmax(gap_mask, axis=-1), (1,2)), axis=1)
+            # load dQ/dx profile and stopping event selection
+            stopping_sel = self.data_manager[self.stopping_sel_dset_name, source_slice].reshape(ev.shape)
+            prof = self.data_manager[self.profile_dset_name, source_slice].reshape(ev.shape)
+            sel_mask = stopping_sel['sel'].astype(bool)
 
-        mu_start = mu_start.reshape(ev.shape + (-1,))
-        mu_end = mu_end.reshape(ev.shape + (-1,))
-        michel_end = michel_end.reshape(ev.shape + (-1,))
+            # find start and end points
+            mu_start = np.take_along_axis(
+                prof['profile_pos'], np.expand_dims(np.argmax(prof['profile_n'] > 0, axis=-1), (1, 2)), axis=1)
+            mu_end = stopping_sel['stop_pt'] + stopping_sel['stop_pt_corr']
+            last_profile_rr = ma.array(prof['profile_rr'], mask=(prof['profile_n'] <= 0) | (prof['profile_rr'] < 0))
+            last_profile_rr = last_profile_rr.min(axis=-1, keepdims=True)
+            last_profile_rr = last_profile_rr.filled(0.)
+            gap_mask = (prof['profile_rr'] <= last_profile_rr) & (prof['profile_n'] > 0)
+            gap_mask[...,:-1] = gap_mask[...,:-1] & (prof['profile_n'][...,1:] == 0)
 
-        # find axes
-        mu_dir = mu_start - mu_end
-        mu_dir /= np.clip(np.linalg.norm(mu_dir, axis=-1, keepdims=True), 1e-15, None)
+            michel_end = np.take_along_axis(
+                prof['profile_pos'], np.expand_dims(np.argmax(gap_mask, axis=-1), (1,2)), axis=1)
 
-        michel_dir = michel_end - mu_end
-        # special case: michel start and end are the same, use average non-profiled position
-        no_michel_mask = np.all(michel_end == mu_end, axis=-1)
-        hit_profile_mask = np.broadcast_to(np.expand_dims(
-            (hit_prof_idx == -1) | ((hit_prof_idx > np.argmax(gap_mask, axis=-1)[...,np.newaxis])
-                                    & np.any(gap_mask, axis=-1, keepdims=True))
-            , -1), hit_xyz.shape)
-        michel_dir[no_michel_mask] = (np.mean(ma.array(hit_xyz, mask=~hit_profile_mask), axis=1) - mu_end)[no_michel_mask]
-        michel_dir[no_michel_mask & ~hit_profile_mask.any(axis=-1).any(axis=-1)]
-        michel_dir /= np.clip(np.linalg.norm(michel_dir, axis=-1, keepdims=True), 1e-15, None)
+            mu_start = mu_start.reshape(ev.shape + (-1,))
+            mu_end = mu_end.reshape(ev.shape + (-1,))
+            michel_end = michel_end.reshape(ev.shape + (-1,))
 
-        # calculate likelihood parameters
-        hit_cos_mu = np.sum((hit_xyz - mu_end[:, np.newaxis, :])
-            * mu_dir[:, np.newaxis, :], axis=-1)
-        hit_cos_e = np.sum((hit_xyz - mu_end[:, np.newaxis, :])
-            * michel_dir[:, np.newaxis, :], axis=-1)
-        hit_d = np.sqrt(np.sum((hit_xyz - mu_end[:, np.newaxis, :])**2, axis=-1))
+            # find axes
+            mu_dir = mu_start - mu_end
+            mu_dir /= np.clip(np.linalg.norm(mu_dir, axis=-1, keepdims=True), 1e-15, None)
 
-        # score hits
-        hit_score = michel_likelihood_score(hit_cos_e, hit_cos_mu, hit_d, *self.michel_likelihood_args)
-        if self.generate_likelihood_pdf and resources['RunData'].is_mc:
-            # FIXME: paths are hardcoded and loaded on each execution
-            event_truth = np.expand_dims(self.data_manager['analysis/muon_capture/truth_labels', source_slice], axis=-1)
-            hit_traj = self.data_manager[source_name, 'charge/hits',
-                                         'charge/packets', 'mc_truth/tracks',
-                                         'mc_truth/trajectories', source_slice]
-            hit_frac = self.data_manager[source_name, 'charge/hits',
-                                         'charge/packets',
-                                         'mc_truth/packet_fraction',
-                                         source_slice]
-            hit_traj = np.take_along_axis(
-                hit_traj, np.expand_dims(np.argmax(hit_frac, axis=-1), axis=(-2,-1)),
-                axis=-2)
-            hit_traj = hit_traj.reshape(hits.shape)
-            hit_label_truth = (
-                ((hit_traj['trackID'] == event_truth['michel_track_id'])
-                 | (hit_traj['parentID'] == event_truth['michel_track_id']))
-                & event_truth['michel'].astype(bool))
+            michel_dir = michel_end - mu_end
+            # if no track-able michel, use charge weighted average position not included in parent muon for michel axis
+            no_michel_mask = np.all(michel_end == stopping_sel['stop_pt'], axis=-1)
+            hit_profile_mask = np.broadcast_to(np.expand_dims(
+                (hit_prof_idx == -1) | ((hit_prof_idx >= np.argmax(prof['profile_rr'] <= 0, axis=-1)[...,np.newaxis]))
+                , -1), hit_xyz.shape)
+            muon_flag = ~hit_profile_mask.any(axis=-1)
+            michel_dir[no_michel_mask] = (ma.average(ma.array(hit_xyz, mask=~hit_profile_mask),
+                                                     weights=np.broadcast_to(hits['q'][...,np.newaxis], hit_xyz.shape), axis=1)
+                          - mu_end)[no_michel_mask]
+            michel_dir /= np.clip(np.linalg.norm(michel_dir, axis=-1, keepdims=True), 1e-15, None)
+            # special case: michel start and end are the same, and no non-profiled hits (will call all of these non-michel hits)
+            no_hit_mask = ~hit_profile_mask.any(axis=-1).any(axis=-1)
 
-            self.michel_likelihood_args[:2] = fill_likelihood_pdf(
-                hit_cos_mu, hit_cos_e, hit_d, hit_label_truth,
-                *self.michel_likelihood_args)
+            # calculate likelihood parameters
+            hit_cos_mu = np.sum((hit_xyz - mu_end[:, np.newaxis, :])
+                                * mu_dir[:, np.newaxis, :], axis=-1)
+            hit_cos_mu /= np.clip(np.linalg.norm(hit_xyz - mu_end[:, np.newaxis, :], axis=-1), 1e-15, None)
+            hit_cos_e = np.sum((hit_xyz - mu_end[:, np.newaxis, :])
+                               * michel_dir[:, np.newaxis, :], axis=-1)
+            hit_cos_e /= np.clip(np.linalg.norm(hit_xyz - mu_end[:, np.newaxis, :], axis=-1), 1e-15, None)
+            hit_d = np.sqrt(np.sum((hit_xyz - mu_end[:, np.newaxis, :])**2, axis=-1))
 
-        # grab michel energy (from stopping muon selection)
-        michel_e = stopping_sel['remaining_e']
+            # score hits
+            hit_score = michel_likelihood_score(hit_cos_mu, hit_cos_e, hit_d, *self.michel_likelihood_args)
+            hit_score = hit_score * (~no_hit_mask[...,np.newaxis])
+            if self.generate_likelihood_pdf and resources['RunData'].is_mc:
+                # FIXME: paths are hardcoded and loaded on each execution
+                event_truth = np.expand_dims(self.data_manager['analysis/muon_capture/truth_labels', source_slice], axis=-1)
+                hit_traj = self.data_manager[source_name, 'charge/hits',
+                                             'charge/packets', 'mc_truth/tracks',
+                                             'mc_truth/trajectories', source_slice]
+                hit_frac = self.data_manager[source_name, 'charge/hits',
+                                             'charge/packets',
+                                             'mc_truth/packet_fraction',
+                                             source_slice]
+                hit_traj = np.take_along_axis(
+                    hit_traj, np.expand_dims(np.argmax(hit_frac, axis=-1), axis=(-2,-1)),
+                    axis=-2)
+                hit_traj = hit_traj.reshape(hits.shape)
+                hit_label_truth = (
+                    ((hit_traj['trackID'] != event_truth['stopping_track_id']))
+                    # | (hit_traj['parentID'] == event_truth['michel_track_id']))
+                    & event_truth['michel'].astype(bool))
 
-        # cut on variables
-        michel_flag = ((np.sum(hit_score > 0, axis=-1) > self.michel_nhit_cut)
-                       | (michel_e > self.michel_e_cut))
+                michel_mask = sel_mask & ~no_hit_mask
+                hist_mask = (~hit_label_truth.mask & ~muon_flag)
+                sig, bkg = fill_likelihood_pdf(
+                    hit_cos_mu[michel_mask][hist_mask[michel_mask]],
+                    hit_cos_e[michel_mask][hist_mask[michel_mask]],
+                    hit_d[michel_mask][hist_mask[michel_mask]],
+                    hit_label_truth[michel_mask][hist_mask[michel_mask]].astype(bool),
+                    *self.michel_likelihood_args)
+                self.michel_likelihood_args[0] = sig
+                self.michel_likelihood_args[1] = bkg
+
+            # grab michel energy (from stopping muon selection)
+            michel_e = stopping_sel['remaining_e']
+
+            # use michel tag to reconstruct energy
+            lifetime = resources['LArData'].electron_lifetime(ev['unix_ts'].astype(float))[0]
+            lifetime = lifetime[..., np.newaxis]
+            hit_q = self.larpix_gain * hits['q'] / np.exp(-hit_drift['t_drift'] * resources['RunData'].crs_ticks / lifetime)
+            hit_e = hit_q * resources['LArData'].ionization_w * self.recomb_factor
+            michel_tagged_e = (((hit_score > 0) & ~muon_flag) * hit_e).sum(axis=-1)
+
+            # cut on variables
+            michel_flag = ((np.sum((hit_score > 0) & ~muon_flag, axis=-1) > self.michel_nhit_cut)
+                           | (michel_tagged_e > self.michel_e_cut))
 
         # create output arrays
         michel_label = np.empty(ev.shape, dtype=self.michel_label_dtype)
-        michel_label['michel_flag'] = michel_flag
-        michel_label['michel_nhit'] = np.sum(hit_score > 0, axis=-1)
-        michel_label['michel_e'] = michel_e
-        michel_label['michel_dir'] = michel_dir
-        michel_label['muon_dir'] = mu_dir
-        michel_label['stop_pt'] = mu_end
+        if len(ev):
+            michel_label['michel_flag'] = michel_flag
+            michel_label['michel_nhit'] = np.sum((hit_score > 0) & ~muon_flag, axis=-1)
+            michel_label['michel_e'] = michel_e
+            michel_label['michel_tagged_e'] = michel_tagged_e
+            michel_label['michel_dir'] = michel_dir
+            michel_label['muon_dir'] = mu_dir
+            michel_label['stop_pt'] = mu_end
+            michel_label['michel_end'] = michel_end
 
         hit_mask = ~hits['id'].mask
         hit_label = np.empty(hit_mask.sum(), dtype=self.hit_label_dtype)
         if np.any(hit_mask):
             hit_label['score'] = hit_score[hit_mask]
-            hit_label['michel_flag'] = hit_score[hit_mask] > 0
+            hit_label['michel_flag'] = ((hit_score > 0) & ~muon_flag)[hit_mask]
+            hit_label['muon_flag'] = muon_flag[hit_mask]
 
         # write to file
         self.data_manager.reserve_data(self.michel_label_dset_name, source_slice)

--- a/module0_flow/analysis/muon_capture_truth_labels.py
+++ b/module0_flow/analysis/muon_capture_truth_labels.py
@@ -250,7 +250,7 @@ class MuonCaptureTruthLabels(H5FlowStage):
         if len(traj):
             ev_idx = np.broadcast_to(np.r_[source_slice][...,np.newaxis], scat_idx.shape)
             ref = np.c_[ev_idx.ravel(), scat_idx.ravel()]
-            ref = ref[~scat_idx.mask.ravel()]
+            ref = ref[~np.broadcast_to(scat_idx.mask.ravel(), ref.shape[0])]
         else:
             ref = np.empty((0,2))
         self.data_manager.reserve_data(self.truth_labels_dset_name + '/scatter_track', source_slice)

--- a/module0_flow/analysis/stopping_muon_selection.py
+++ b/module0_flow/analysis/stopping_muon_selection.py
@@ -41,12 +41,11 @@ class StoppingMuonSelection(H5FlowStage):
         projected_length_cut=30, # mm
         veto_charge_cut=100e3, # e-
         profile_dx=22, # mm
-        profile_max_range=1600, # mm
+        profile_max_range=2000, # mm
         larpix_gain=250, # e/mV
         larpix_noise=500,  # e/mm
         proton_classifier_cut=0.05,
         muon_classifier_cut=0.08,
-        mcs_weight=0.5,
         dqdx_peak_cut=12e3, # e/mm
         profile_search_dx=22, # mm
         remaining_e_cut=85e3, # keV
@@ -64,7 +63,7 @@ class StoppingMuonSelection(H5FlowStage):
     event_sel_dset_name = 'event_sel_reco'
     event_profile_dset_name = 'event_profile'
     event_sel_truth_dset_name = 'event_sel_truth'
-    hit_profile_dset_name = 'hit_profile_id'
+    hit_profile_dset_name = 'hit_profile'
 
     event_sel_dtype = np.dtype([('sel', 'u1'),
                                 ('stop', 'u1'),
@@ -91,7 +90,7 @@ class StoppingMuonSelection(H5FlowStage):
             ('mip_likelihood', 'f8', (profile_bins, 2)),
         ])
 
-    hit_profile_id_dtype = 'i4'
+    hit_profile_dtype = np.dtype([('idx','i4'),('rr','f8')])
 
     def __init__(self, **params):
         super(StoppingMuonSelection, self).__init__(**params)
@@ -131,7 +130,7 @@ class StoppingMuonSelection(H5FlowStage):
         self.data_manager.create_dset(f'{self.path}/{self.event_profile_dset_name}',
                                       self.event_profile_dtype)
         self.data_manager.create_dset(f'{self.path}/{self.hit_profile_dset_name}',
-                                      self.hit_profile_id_dtype)
+                                      self.hit_profile_dtype)
         self.data_manager.create_ref(f'{self.path}/{self.hit_profile_dset_name}', self.hits_dset_name)
         if self.is_mc:
             self.data_manager.create_dset(f'{self.path}/{self.event_sel_truth_dset_name}',
@@ -338,7 +337,7 @@ class StoppingMuonSelection(H5FlowStage):
         return rv
 
     @staticmethod
-    def profile_likelihood(profile_rr, profile_dqdx, profile_pos, range_table, type='', mcs_weight=0.25):
+    def profile_likelihood(profile_rr, profile_dqdx, profile_pos, range_table, type='', mcs_weight=0.5):
         '''
             Calculates the log-likelihood score of a given dqdx v. residual range profile
             using a Moyal-distribution approximation.
@@ -413,28 +412,30 @@ class StoppingMuonSelection(H5FlowStage):
         np.place(packed_dqdx, place_mask, profile_dqdx[valid_mask])
         np.place(packed_rr, place_mask, profile_rr[valid_mask])
 
-        interp_angle_width = interp_angle_width(np.clip(packed_rr, min_range, max_range))
+        #interp_angle_width = interp_angle_width(np.clip(packed_rr, min_range, max_range))
+        interp_angle_width = interp_angle_width(np.clip(profile_rr, min_range, max_range))
 
         d = packed_pos[..., 1:, :] - packed_pos[..., :-1, :]
-        d = d * ((np.linalg.norm(packed_pos[..., 1:, :], axis=-1, keepdims=True) > 0) *
-                 (np.linalg.norm(packed_pos[..., :-1, :], axis=-1, keepdims=True) > 0))
+        d = d * place_mask[...,1:,np.newaxis] * place_mask[...,:-1,np.newaxis]
         angle = np.zeros_like(packed_dqdx)
         norm = np.linalg.norm(d[..., 1:, :], axis=-1) * np.linalg.norm(d[..., :-1, :], axis=-1)
-        if any_valid:
-            angle[..., 1:-1] = np.maximum(np.sum(d[..., 1:, :] * d[..., :-1, :], axis=-1), 1e-15) / np.maximum(norm, 1e-15)
-            angle[..., 1:-1] = np.arccos(angle[..., 1:-1])
-            angle[..., 0] = angle[..., 1]
-            angle[..., -1] = angle[..., -2]
-
-#        angle_term = stats.norm.logpdf(angle, loc=0, scale=interp_angle_width) + np.log(2)
-        angle_term = stats.expon.logpdf(angle, scale=interp_angle_width) + np.log(2)
-#         angle_term = -np.abs(angle) / np.pi
-        if any_valid:
-            np.put_along_axis(angle_term, np.argmin(np.abs(packed_rr), axis=-1)[..., np.newaxis], -np.log(2), axis=-1)
+        if any_valid and angle.shape[-1] > 1:
+            angle[..., 1:-1] = np.sum(d[..., 1:, :] * d[..., :-1, :], axis=-1) / np.maximum(norm, 1e-15)
+            angle = np.arccos(angle) 
+            #angle[..., 0] = angle[..., 1]
+            #angle[..., -1] = angle[..., -2]
 
         # and now unpack profile pts
         rv_angle_term = np.zeros(valid_mask.shape)
-        np.place(rv_angle_term, valid_mask, angle_term[place_mask])
+        np.place(rv_angle_term, valid_mask, angle[place_mask])
+
+        #angle_term = stats.norm.logpdf(angle, loc=0, scale=interp_angle_width) + np.log(2)
+        rv_angle_term = stats.expon.logpdf(rv_angle_term, scale=interp_angle_width) + np.log(2)
+#         angle_term = -np.abs(angle) / np.pi
+        #if any_valid:
+        #    np.put_along_axis(angle_term, np.argmin(np.abs(packed_rr), axis=-1)[..., np.newaxis], -np.log(2), axis=-1)
+        if any_valid:
+            np.put_along_axis(rv_angle_term, np.argmin(np.abs(profile_rr), axis=-1)[..., np.newaxis], -np.log(2), axis=-1)
 
         return dqdx_term, rv_angle_term * mcs_weight
 
@@ -576,6 +577,7 @@ class StoppingMuonSelection(H5FlowStage):
         ds = np.zeros((n, sample_points))
         pos = np.zeros((n, sample_points, 3))
         hit_prof_idx = np.full(hit_q.shape, -1, dtype=int)
+        hit_prof_s = np.full(hit_q.shape, 0, dtype=float)
 
         hit_mask = ~hit_q.mask
 
@@ -583,23 +585,23 @@ class StoppingMuonSelection(H5FlowStage):
         traj = np.zeros((n, sample_points, 3))
         start_pt = seed_pt[...,0:1,:]
         end_pt = start_pt.copy()
-        traj[...,0:1,:] = seed_pt
+        traj[...,0:1,:] = seed_pt.copy()
         local_mask = np.linalg.norm(hit_xyz - seed_pt, axis=-1, keepdims=True) < search_dx
         local_mask = np.broadcast_to(hit_mask[...,np.newaxis] & local_mask, hit_xyz.shape)
         curr_direction = ma.array(hit_xyz - seed_pt, mask=~local_mask).mean(axis=-2)
         curr_direction /= np.clip(np.linalg.norm(curr_direction, axis=-1, keepdims=True),1e-15,None)
-        s = np.zeros((n, sample_points))
-
+        hit_mask = hit_mask & ~local_mask[...,0]
+        
         i = 0
         while (i < sample_points-1) and np.any(hit_mask):
             i += 1
             
             # collect hits in local region
             dr = (hit_xyz - traj[...,i-1,np.newaxis,:])
-            dl = np.linalg.norm(dr * curr_direction[...,np.newaxis,:], axis=-1, keepdims=True)
-            # forward = np.sum(dx * curr_direction[...,np.newaxis,:], axis=-1, keepdims=True) > 0
+            dl = np.sum(dr * curr_direction[...,np.newaxis,:], axis=-1, keepdims=True)
+            forward = dl > 0
             dt = np.linalg.norm(dr - dl * curr_direction[...,np.newaxis,:], axis=-1, keepdims=True)
-            local_mask = (dl < dx) & (dt < dx/2) & hit_mask[...,np.newaxis] # & forward
+            local_mask = (dl < dx) & (dt < dx/2) & hit_mask[...,np.newaxis] & forward
 
             # if none found, expand search radius
             search_factor = 1
@@ -607,6 +609,8 @@ class StoppingMuonSelection(H5FlowStage):
                 r = np.linalg.norm(dr, axis=-1, keepdims=True)
                 local_mask = (local_mask | ((r < search_factor * search_dx) & hit_mask[...,np.newaxis] & ~(local_mask).any(axis=-2, keepdims=True)))
                 search_factor += 1
+                if search_factor > 5:
+                    break
 
             # if no more hits found, continue
             if not np.any(local_mask):
@@ -632,10 +636,11 @@ class StoppingMuonSelection(H5FlowStage):
         alpha = np.sum(dr * traj_dr, axis=-1) / traj_l[...,0] # (ev, hit, traj-1)
 
         # find closest segment
-        d = np.linalg.norm(dr - traj_dr * np.clip(alpha[...,np.newaxis],0,1) * traj_l, axis=-1) # (ev, hit, traj-1)
-        d[hit_q.mask] = np.inf # remove invalid hits
-        d[...,i-1:] = np.inf # remove invalid segments
+        d = np.linalg.norm(dr - traj_dr * np.clip(alpha[...,np.newaxis], 0, 1) * traj_l, axis=-1) # (ev, hit, traj-1)
+        d = ma.array(d, mask=(hit_q.mask[...,np.newaxis] | (d > dx/2)))
+        d.mask[...,i-1:] = True # remove invalid segments
         iseg_min = np.argmin(d, axis=-1) # (ev, hit)
+        iseg_min[np.take_along_axis(d.mask, iseg_min[...,np.newaxis], axis=-1).reshape(iseg_min.shape)] = -1
 
         # calculate segment range
         s = np.concatenate([np.zeros(traj_l.shape[:-2] + (1,1)), np.cumsum(traj_l, axis=-2)], axis=-2) # (ev, 1, traj-1, 1)
@@ -648,18 +653,43 @@ class StoppingMuonSelection(H5FlowStage):
         hit_prof_idx = np.clip(np.digitize(hit_s, bins=bins) - 1, 0, sample_points-1)
         hit_prof_idx[hit_q.mask] = -1
 
+        sample_point_s = np.zeros_like(ds)
+        prev_pos = traj[...,0,:]
         for i in range(sample_points):
-            if not np.any(hit_prof_idx >= i):
-                break
-            hit_mask = hit_prof_idx == i
-            any_hit_mask = hit_mask.sum(axis=-1) >= 1
-            s = ma.array(hit_s, mask=~hit_mask)
-            ds[...,i] = (np.max(s, axis=-1) - np.min(s, axis=-1)) * any_hit_mask
-            dq[...,i] = (np.sum(ma.array(hit_q, mask=~hit_mask), axis=-1)) * any_hit_mask
-            dn[...,i] = (np.sum(hit_mask, axis=-1)) * any_hit_mask
-            pos[...,i,:] = (ma.average(ma.array(hit_xyz, mask=~np.broadcast_to(hit_mask[...,np.newaxis], hit_xyz.shape)),
+            #if not np.any(hit_prof_idx >= i):
+            #    break
+            
+            # grab hits from current trajectory point
+            hit_mask = (hit_prof_idx == i) & (~hit_q.mask)
+            any_hit_mask = hit_mask.any(axis=-1)
+            #if not np.any(any_hit_mask):
+            #    continue
+
+            # re-estimate position and only use "local" hits
+            traj_hit_s = ma.array(hit_s, mask=~hit_mask)
+            local_pos = (ma.average(ma.array(hit_xyz, mask=~np.broadcast_to(hit_mask[...,np.newaxis], hit_xyz.shape)),
                                         weights=np.broadcast_to(hit_q[...,np.newaxis], hit_xyz.shape), axis=-2)
                              * any_hit_mask[...,np.newaxis])
+            local_pos[~any_hit_mask,:] = prev_pos[~any_hit_mask,:]
+            prev_pos = local_pos
+            
+            hit_mask = hit_mask & (np.linalg.norm(hit_xyz - local_pos[...,np.newaxis,:], axis=-1) < dx)
+            any_hit_mask = hit_mask.any(axis=-1)
+
+            #if not np.any(any_hit_mask):
+            #    continue
+
+            # fill output arrays
+            pos[...,i,:] = local_pos
+            dq[...,i] = (np.sum(ma.array(hit_q, mask=~hit_mask), axis=-1)) * any_hit_mask
+            dn[...,i] = (np.sum(hit_mask, axis=-1)) * any_hit_mask            
+            local_dir = pos[...,i,:] - pos[...,i-1,:] if i > 0 else traj[...,1,:] - traj[...,0,:]
+            if i > 0:
+                sample_point_s[...,i:] += np.linalg.norm(local_dir, axis=-1)[...,np.newaxis]
+            local_dir /= np.clip(np.linalg.norm(local_dir, axis=-1, keepdims=True), 1e-15, None)
+            local_s = ma.array(np.sum((hit_xyz - pos[...,i:i+1,:]) * local_dir[...,np.newaxis,:], axis=-1), mask=~hit_mask)
+            hit_prof_s[hit_mask] = (local_s + sample_point_s[...,i:i+1])[hit_mask]
+            ds[...,i] = (np.max(local_s, axis=-1) - np.min(local_s, axis=-1)) * any_hit_mask
 
         r_dq = np.zeros((orig_len,) + dq.shape[1:])
         r_dn = np.zeros((orig_len,) + dn.shape[1:], dtype=int)
@@ -668,6 +698,7 @@ class StoppingMuonSelection(H5FlowStage):
         r_pos = np.zeros((orig_len,) + pos.shape[1:])
         r_ds = np.zeros((orig_len,) + ds.shape[1:])
         r_hit_prof_idx = np.zeros((orig_len,) + hit_prof_idx.shape[1:], dtype=int) - 1
+        r_hit_prof_s = np.zeros((orig_len,) + hit_prof_s.shape[1:], dtype=float)    
 
         np.place(r_dq, np.broadcast_to(mask[..., np.newaxis], r_dq.shape), dq)
         np.place(r_dn, np.broadcast_to(mask[..., np.newaxis], r_dn.shape), dn)
@@ -676,187 +707,9 @@ class StoppingMuonSelection(H5FlowStage):
         np.place(r_end_pt, np.broadcast_to(mask[..., np.newaxis, np.newaxis], r_end_pt.shape), end_pt)
         np.place(r_pos, np.broadcast_to(mask[..., np.newaxis, np.newaxis], r_pos.shape), pos)
         np.place(r_hit_prof_idx, np.broadcast_to(mask[..., np.newaxis], r_hit_prof_idx.shape), hit_prof_idx)
+        np.place(r_hit_prof_s, np.broadcast_to(mask[..., np.newaxis], r_hit_prof_s.shape), hit_prof_s)        
 
-        return r_dq, r_dn, r_ds, r_start_pt, r_end_pt, r_pos, r_hit_prof_idx
-
-    
-    @staticmethod
-    def profiled_dqdx(tracks, seed_pt, hit_xyz, hit_q, dx, max_range, search_dx, pixel_pitch, mask=None):
-        '''
-            Generate dQ/dx profile. Algorithm is the following:
-
-             1. Find track nearest to seed point
-
-             2. Orient track in direction away from seed point
-
-             3. Collect hits that lie within ``dx`` mm along the track trajectory
-
-             4. Assign hits an overall position along event according to the projection onto the track trajectory
-
-             5. Fill dQ/dx bins with hit charge according to hit position
-
-             6. Set next iteration seed point as current track end point
-
-             7. Repeat, removing previously used tracks from each iteration
-
-            The output array contains ``int(max_range / dx)`` bins with the
-            first and last bins being overflow bins.
-
-            This is an expensive operation so a ``mask`` can be provided to skip
-            the analysis of certain events. The returned array will not contain
-            meaningful values for these entries.
-
-            :param tracks: masked array, shape: (..., M)
-
-            :param seed_pt: masked array, shape: (..., 3)
-
-            :param hit_xyz: masked array, shape: (..., n, 3)
-
-            :param hit_q: masked array, shape: (..., n)
-
-            :param dx: float, bin size
-
-            :param search_dx: float, distance to look for next track
-
-            :param max_range: float, maximum bin
-
-            :param pixel_pitch: float, pixel pitch for dx correction
-
-            :returns: ``tuple`` of masked arrays, shape: (..., m). ``dq``, ``dn``, ``start_pt``, ``end_pt``, ``pos``, ``hit_prof_idx``
-        '''
-        orig_len = len(tracks)
-        if mask is not None:
-            tracks = tracks[mask]
-            seed_pt = seed_pt[mask]
-            hit_xyz = hit_xyz[mask]
-            hit_q = hit_q[mask]
-
-        seed_d = np.minimum(np.linalg.norm(tracks['trajectory'][..., 0, :] - seed_pt, axis=-1),
-                            np.linalg.norm(tracks['trajectory'][..., -1, :] - seed_pt, axis=-1))
-        seed_track = np.expand_dims(np.argmin(seed_d, axis=-1), axis=-1)
-
-        start_pt = seed_pt.copy()
-
-        dq = np.zeros((len(tracks), int(max_range / dx)))
-        dn = np.zeros((len(tracks), int(max_range / dx)), dtype=int)
-        pos = np.zeros((len(tracks), int(max_range / dx), 3))
-        hit_prof_idx = np.full((len(tracks), hit_q.shape[-1]), -1, dtype=int)
-        s_min = np.full((len(tracks), int(max_range / dx)), max_range + 1.)
-        s_max = np.full((len(tracks), int(max_range / dx)), -max_range - 1.)
-
-        track_mask = ~tracks['id'].mask.copy()  # True == include
-        iter_mask = np.zeros_like(~tracks['id'].mask)  # True == include
-        hit_mask = ~(hit_q.mask | np.any(hit_xyz.mask, axis=-1))  # True == include
-
-        np.put_along_axis(iter_mask, seed_track, True, axis=-1)
-
-        s = 0
-        bins = np.linspace(0, max_range, dq.shape[-1])
-        for _ in range(tracks.shape[-1]):
-
-            # find seed trajectory
-            traj = np.take_along_axis(tracks, seed_track, axis=-1)['trajectory'].copy()
-
-            # orient trajectory according to previous seed point
-            traj_start_d = np.linalg.norm(traj[..., 0, :] - seed_pt, axis=-1, keepdims=True)
-            traj_end_d = np.linalg.norm(traj[..., -1, :] - seed_pt, axis=-1, keepdims=True)
-            is_reversed_traj = (traj_end_d < traj_start_d)
-            is_reversed_traj = np.expand_dims(is_reversed_traj, axis=-1)
-            traj = np.where(is_reversed_traj, traj[..., ::-1, :], traj)
-            # (N, 1, npt, 3)
-
-            # get trajectory displacement vectors
-            traj_start = traj[..., :-1, :]
-            traj_end = traj[..., 1:, :]
-            traj_dx = traj_end - traj_start
-            traj_length = np.linalg.norm(traj_dx, axis=-1, keepdims=True)
-            traj_length = np.clip(traj_length, 1e-15, None)
-            traj_n = traj_dx / traj_length
-            # (N, 1, npt-1, 3)
-
-            # collect hits within dx of trajectory
-            hit_dx = np.expand_dims(hit_xyz, axis=-2) - traj_start
-            hit_td = np.linalg.norm(hit_dx - np.sum(hit_dx * traj_n, axis=-1, keepdims=True) * traj_n, axis=-1)
-            hit_alpha = np.sum(hit_dx * traj_n, axis=-1) / traj_length[..., 0]
-            hit_on_traj = (hit_alpha < 1) & (hit_alpha > 0)
-            hit_near_traj_pt = ((np.linalg.norm(np.expand_dims(hit_xyz, axis=-2) - traj_start, axis=-1) < dx)
-                                | (np.linalg.norm(np.expand_dims(hit_xyz, axis=-2) - traj_end, axis=-1) < dx))
-            itraj_min_td = np.expand_dims(np.argmin(
-                ma.array(hit_td, mask=~(hit_on_traj | hit_near_traj_pt)),
-                axis=-1), axis=-1)
-            hit_min_td = np.take_along_axis(hit_td, itraj_min_td, axis=-1)
-            traj_hit_mask = ((hit_min_td < dx/2)[..., 0] & hit_mask
-                             & (np.any(hit_on_traj, axis=-1) | np.any(hit_near_traj_pt, axis=-1)))
-            hit_mask = hit_mask & ~traj_hit_mask  # remove from next iteration
-            # (N, nhit)
-
-            # project hits onto track
-            traj_s = np.cumsum(traj_length[..., 0], axis=-1) + s - traj_length[..., 0]  # (N, 1, npts-1)
-            hit_s = hit_alpha * traj_length[..., 0] + traj_s  # (N, nhit, npts-1) * (N, 1, npt-1, 1)
-            hit_s = np.take_along_axis(hit_s, itraj_min_td, axis=-1)[..., 0]
-            # (N, nhit)
-
-            # and create a histogram
-            i_bin = np.expand_dims(np.clip(np.digitize(hit_s, bins=bins) - 1, 0, len(bins) - 1), axis=-1)
-            np.place(hit_prof_idx, traj_hit_mask, i_bin)
-            # (N, nhit, nbin)
-            q_mask = ((i_bin == np.expand_dims(np.indices(dq.shape)[-1], axis=-2))
-                      & np.expand_dims(traj_hit_mask, axis=-1)
-                      & np.expand_dims(np.take_along_axis(track_mask, seed_track, axis=-1), axis=-1)
-                      & np.expand_dims(np.take_along_axis(iter_mask, seed_track, axis=-1), axis=-1)
-                      )
-            masked_q = ma.array(np.broadcast_to(hit_q[..., np.newaxis], q_mask.shape), mask=~q_mask)
-            xyz_mask = np.broadcast_to(q_mask[..., np.newaxis], q_mask.shape + (3,))
-            masked_xyz = ma.array(np.broadcast_to(hit_xyz[..., np.newaxis, :], xyz_mask.shape), mask=~xyz_mask)
-            update_elem = np.any(~q_mask, axis=-2)
-            dq[update_elem] = dq[update_elem] + ma.sum(masked_q, axis=-2).filled(0)[update_elem]
-            dn[update_elem] = dn[update_elem] + ma.sum(~masked_q.mask, axis=-2).filled(0)[update_elem]
-            pos[update_elem] = pos[update_elem] + ma.sum(masked_xyz, axis=-3).filled(0)[update_elem]
-
-            masked_s = ma.array(np.broadcast_to(hit_s[..., np.newaxis], q_mask.shape), mask=~q_mask)
-            s_min[update_elem] = ma.minimum(
-                s_min[update_elem], ma.min(masked_s, axis=-2).filled(max_range + 1)[update_elem])
-            s_max[update_elem] = ma.maximum(
-                s_max[update_elem], ma.max(masked_s, axis=-2).filled(-max_range - 1)[update_elem])
-
-            # termination conditions
-            np.put_along_axis(track_mask, seed_track, False, axis=-1)
-            if (np.all([s > max_range]) or not np.any(track_mask) or not np.any(hit_mask)):
-                break
-
-            # update variables
-            s = s + np.sum(traj_length[..., 0], axis=-1)[..., np.newaxis]
-            seed_pt = traj[..., -1, :].copy()
-            traj_distance = np.sqrt(ma.sum((tracks['trajectory'] - np.expand_dims(seed_pt, axis=-2))**2, axis=-1))
-            traj_mask = np.any((traj_distance < search_dx) & track_mask[..., np.newaxis], axis=-1)
-            seed_track = np.expand_dims(np.argmax(traj_mask, axis=-1), axis=-1)
-
-            iter_mask[:] = False
-            np.put_along_axis(iter_mask, seed_track, np.take_along_axis(traj_mask, seed_track, axis=-1), axis=-1)
-
-            if not np.any(traj_mask):
-                break
-
-        pos /= np.maximum(dn[..., np.newaxis], 1e-15)
-        end_pt = np.take_along_axis(pos, np.argmax(dq / np.maximum(s_max - s_min, 1e-15) * (dn > 0), axis=-1)[..., np.newaxis, np.newaxis], axis=-2)
-
-        r_dq = np.zeros((orig_len,) + dq.shape[1:])
-        r_dn = np.zeros((orig_len,) + dn.shape[1:])
-        r_start_pt = np.zeros((orig_len,) + start_pt.shape[1:])
-        r_end_pt = np.zeros((orig_len,) + end_pt.shape[1:])
-        r_pos = np.zeros((orig_len,) + pos.shape[1:])
-        r_ds = np.zeros((orig_len,) + s_min.shape[1:])
-        r_hit_prof_idx = np.zeros((orig_len,) + hit_prof_idx.shape[1:]) - 1
-
-        np.place(r_dq, np.broadcast_to(mask[..., np.newaxis], r_dq.shape), dq)
-        np.place(r_dn, np.broadcast_to(mask[..., np.newaxis], r_dn.shape), dn)
-        np.place(r_ds, np.broadcast_to(mask[..., np.newaxis], r_ds.shape), (s_max - s_min))
-        np.place(r_start_pt, np.broadcast_to(mask[..., np.newaxis, np.newaxis], r_start_pt.shape), start_pt)
-        np.place(r_end_pt, np.broadcast_to(mask[..., np.newaxis, np.newaxis], r_end_pt.shape), end_pt)
-        np.place(r_pos, np.broadcast_to(mask[..., np.newaxis, np.newaxis], r_pos.shape), pos)
-        np.place(r_hit_prof_idx, np.broadcast_to(mask[..., np.newaxis], r_hit_prof_idx.shape), hit_prof_idx)
-
-        return r_dq, r_dn, r_ds, r_start_pt, r_end_pt, r_pos, r_hit_prof_idx
+        return r_dq, r_dn, r_ds, r_start_pt, r_end_pt, r_pos, r_hit_prof_idx, r_hit_prof_s
 
     @staticmethod
     def mean_neg_loglikelihood(r0, range_table, profile_n, profile_dqdx, profile_rr, profile_pos):
@@ -864,9 +717,10 @@ class StoppingMuonSelection(H5FlowStage):
         pt_likelihood_dqdx, pt_likelihood_mcs = StoppingMuonSelection.profile_likelihood(
             profile_rr, profile_dqdx, profile_pos, range_table)
         profile_n, profile_dqdx, profile_rr = np.broadcast_arrays(profile_n, profile_dqdx, profile_rr)
-        pt_likelihood_mcs = ma.masked_where((profile_n <= 0) & (profile_rr <= 0), pt_likelihood_mcs)
-        pt_likelihood_dqdx = ma.masked_where((profile_rr <= 0), pt_likelihood_dqdx)
-        #pt_likelihood_dqdx = ma.masked_where((profile_n <= 0) | (profile_rr < 0), pt_likelihood_dqdx)
+        pt_likelihood_mcs = ma.masked_where((profile_n <= 0) | (profile_rr <= 0), pt_likelihood_mcs)
+        #pt_likelihood_dqdx = ma.masked_where((profile_rr <= 0), pt_likelihood_dqdx)
+        pt_likelihood_dqdx = ma.masked_where((profile_n <= 0) | (profile_rr <= 0), pt_likelihood_dqdx)
+
         mean_likelihood = -pt_likelihood_dqdx.mean(axis=-1) - pt_likelihood_mcs.mean(axis=-1)
         return mean_likelihood
 
@@ -959,9 +813,8 @@ class StoppingMuonSelection(H5FlowStage):
                              & (ma.sum(seed_track_mask, axis=-1) == 1))
 
         # now check the likelihood of a stopping muon
-        # first generated the dQ/dx profile
-        #dq, dn, ds, start_pt, end_pt, pos, hit_prof_idx = self.profiled_dqdx(
-        dq, dn, ds, start_pt, end_pt, pos, hit_prof_idx = self.profiled_dqdx_kalman(    
+        # first generate the dQ/dx profile
+        dq, dn, ds, start_pt, end_pt, pos, hit_prof_idx, hit_prof_s = self.profiled_dqdx_kalman(
             tracks, seed_pt, hit_xyz, hit_q, mask=event_is_stopping,
             dx=self.profile_dx, search_dx=self.profile_search_dx,
             max_range=self.profile_max_range, pixel_pitch=resources['Geometry'].pixel_pitch)
@@ -971,21 +824,30 @@ class StoppingMuonSelection(H5FlowStage):
         profile_dqdx[dn <= 0] = 0
 
         # make an initial guess for the stopping point (maximum 2 dQ/dx bins)
-        profile_rr = np.linalg.norm(pos[...,1:,:] - pos[...,:-1,:], axis=-1) * (dn[...,1:] > 0) * (dn[...,:-1] > 0)
-        profile_rr = ma.masked_where((dn[...,1:] <= 0) | (dn[...,:-1] <= 0), profile_rr)
-        np.place(profile_rr, (dn[...,1:] <= 0) | (dn[...,:-1] <= 0), np.broadcast_to(ma.median(profile_rr, axis=-1, keepdims=True), profile_rr.shape))
+        profile_rr = np.linalg.norm(pos[...,1:,:] - pos[...,:-1,:], axis=-1)
         profile_rr = np.concatenate((np.zeros(profile_rr.shape[:-1]+(1,)), profile_rr), axis=-1)
         profile_rr = np.cumsum(profile_rr, axis=-1)
         
         i_max = np.argsort(profile_dqdx, axis=-1)[...,-2:]
-        profile_rr0 = np.take_along_axis(profile_rr, i_max[...,0:1], axis=-1) - profile_rr
-        profile_rr1 = np.take_along_axis(profile_rr, i_max[...,1:2], axis=-1) - profile_rr        
+        profile_offset0 = np.take_along_axis(profile_rr, i_max[...,0:1], axis=-1)
+        profile_offset1 = np.take_along_axis(profile_rr, i_max[...,1:2], axis=-1)
+        
+        # refine guess by using the hit with the largest charge
+        hit_near_stop0 = (hit_prof_idx == i_max[...,0:1])
+        hit_near_stop1 = (hit_prof_idx == i_max[...,1:2])
+        profile_offset0[hit_near_stop0.any(axis=-1)] = np.take_along_axis(
+            hit_prof_s, np.argmax(ma.array(hit_q, mask=~hit_near_stop0), axis=-1)[...,np.newaxis], axis=-1)[hit_near_stop0.any(axis=-1)]
+        profile_offset1[hit_near_stop1.any(axis=-1)] = np.take_along_axis(
+            hit_prof_s, np.argmax(ma.array(hit_q, mask=~hit_near_stop1), axis=-1)[...,np.newaxis], axis=-1)[hit_near_stop1.any(axis=-1)]
+
+        profile_rr0 = profile_offset0 - profile_rr
+        profile_rr1 = profile_offset1 - profile_rr        
 
         # perform a fit for the stopping point assuming a muon or a proton
         muon_r0 = np.zeros(profile_dqdx.shape[:-1])
         proton_r0 = np.zeros(profile_dqdx.shape[:-1])
-        max_range = self.profile_dx  # within +/- 1 profile bins
-        sample_factor = 20  # resolution is profile bin/10
+        max_range = 0 #self.profile_dx  # within +/- 1 profile bins
+        sample_factor = 1 #20  # resolution is profile bin/10
         for i in range(muon_r0.shape[0]):
             if np.any((profile_n[i] > 0)):
                 valid_mask = profile_n[i] > 0
@@ -1000,10 +862,10 @@ class StoppingMuonSelection(H5FlowStage):
                                 np.minimum(+max_range, rr[valid_mask].max()))
                     rr_offset = np.expand_dims(
                         np.linspace(rr_range[0], rr_range[1],
-                                    sample_factor * int(np.diff(rr_range) / self.profile_dx)),
+                                    np.clip(sample_factor * int(np.diff(rr_range) / self.profile_dx),1,None)),
                         axis=-1)
                     close_dqdx = np.take_along_axis(profile_dqdx[i:i + 1], np.argmin(np.abs(rr[np.newaxis,...] - rr_offset), axis=-1)[..., np.newaxis], axis=-1)
-                    mask = (close_dqdx > self.dqdx_peak_cut)
+                    mask = np.ones_like((close_dqdx > self.dqdx_peak_cut)) # ignore dQ/dx mask
                     #if not np.any(mask):
                     #    continue
 
@@ -1035,13 +897,13 @@ class StoppingMuonSelection(H5FlowStage):
             self.muon_range_table)
 
         muon_likelihood_mcs = ma.masked_where(
-            (dn == 0),
+            (dn == 0) | (profile_rr - muon_r0[..., np.newaxis] <= 0),
             muon_likelihood_mcs)
         proton_likelihood_mcs = ma.masked_where(
-            (dn == 0),
+            (dn == 0) | (profile_rr - proton_r0[..., np.newaxis] <= 0),
             proton_likelihood_mcs)
         mip_likelihood_mcs = ma.masked_where(
-            (dn == 0),
+            (dn == 0) | (profile_rr - muon_r0[..., np.newaxis] <= 0),
             mip_likelihood_mcs)
         muon_likelihood_dqdx = ma.masked_where(
             (dn == 0) | (profile_rr - muon_r0[..., np.newaxis] <= 0),
@@ -1068,6 +930,9 @@ class StoppingMuonSelection(H5FlowStage):
         end_pt_in_fid = resources['Geometry'].in_fid(
             end_pt.reshape(-1, 3), cathode_fid=self.cathode_fid_cut, field_cage_fid=self.fid_cut, anode_fid=self.anode_fid_cut)
         end_pt_in_fid = end_pt_in_fid.reshape(tracks.shape[0])
+
+        # estimate residual range for each hit
+        hit_prof_rr = profile_rr.max(axis=-1, keepdims=True) - hit_prof_s     
 
         # calculate "additional" energy (all energy not associated to the parent muon) assuming nominal michel dE/dx
         q_sum = hit_q.sum(axis=-1) - ma.array(dq, mask=(np.around(profile_rr/self.profile_dx) * self.profile_dx < 0) | (profile_n <= 0)).sum(axis=-1)
@@ -1133,6 +998,12 @@ class StoppingMuonSelection(H5FlowStage):
             event_profile['proton_likelihood'][..., 1] = proton_likelihood_mcs
             event_profile['mip_likelihood'][..., 1] = mip_likelihood_mcs
 
+        hit_profile = np.zeros_like(hit_prof_idx, dtype=self.hit_profile_dtype)
+        if len(hit_profile):
+            hit_profile['idx'] -= 1
+            hit_profile['idx'][~hits['id'].mask] = hit_prof_idx[~hits['id'].mask]
+            hit_profile['rr'][~hits['id'].mask] = hit_prof_rr[~hits['id'].mask]
+
         if self.is_mc:
             event_true_sel = np.zeros(len(tracks), dtype=self.event_sel_dtype)
             if len(event_true_sel):
@@ -1161,7 +1032,7 @@ class StoppingMuonSelection(H5FlowStage):
         self.data_manager.write_data(f'{self.path}/{self.event_profile_dset_name}',
                                      event_profile_slice, event_profile)
         self.data_manager.write_data(f'{self.path}/{self.hit_profile_dset_name}',
-                                     event_hits_slice, hit_prof_idx[~hits['id'].mask])
+                                     event_hits_slice, hit_profile[~hits['id'].mask])
         self.data_manager.write_ref(f'{self.path}/{self.hit_profile_dset_name}',
                 self.hits_dset_name, np.c_[event_hits_slice, hits['id'].compressed()])
         if self.is_mc:

--- a/module0_flow/analysis/stopping_muon_selection.py
+++ b/module0_flow/analysis/stopping_muon_selection.py
@@ -337,7 +337,7 @@ class StoppingMuonSelection(H5FlowStage):
         return rv
 
     @staticmethod
-    def profile_likelihood(profile_rr, profile_dqdx, profile_pos, range_table, type='', mcs_weight=0.5):
+    def profile_likelihood(profile_rr, profile_dqdx, profile_pos, range_table, type='', mcs_weight=0.0625):
         '''
             Calculates the log-likelihood score of a given dqdx v. residual range profile
             using a Moyal-distribution approximation.

--- a/module0_flow/analysis/stopping_muon_selection.py
+++ b/module0_flow/analysis/stopping_muon_selection.py
@@ -420,8 +420,10 @@ class StoppingMuonSelection(H5FlowStage):
         angle = np.zeros_like(packed_dqdx)
         norm = np.linalg.norm(d[..., 1:, :], axis=-1) * np.linalg.norm(d[..., :-1, :], axis=-1)
         if any_valid and angle.shape[-1] > 1:
-            angle[..., 1:-1] = np.sum(d[..., 1:, :] * d[..., :-1, :], axis=-1) / np.maximum(norm, 1e-15)
-            angle = np.arccos(angle) 
+            angle[..., 2:] = np.sum(d[..., 1:, :] * d[..., :-1, :], axis=-1) / np.maximum(norm, 1e-15)
+            angle = np.arccos(angle)
+            angle[..., 0] = 0
+            angle[..., 1] = 0
             #angle[..., 0] = angle[..., 1]
             #angle[..., -1] = angle[..., -2]
 
@@ -435,6 +437,7 @@ class StoppingMuonSelection(H5FlowStage):
         #if any_valid:
         #    np.put_along_axis(angle_term, np.argmin(np.abs(packed_rr), axis=-1)[..., np.newaxis], -np.log(2), axis=-1)
         if any_valid:
+            # don't count the last profile point towards score
             np.put_along_axis(rv_angle_term, np.argmin(np.abs(profile_rr), axis=-1)[..., np.newaxis], -np.log(2), axis=-1)
 
         return dqdx_term, rv_angle_term * mcs_weight


### PR DESCRIPTION
Tweaks the dQ/dx profile to no longer use a density correction or dx correction by directly calculating the dx at each sample point using the segment intersection with a cube and removing disabled channels.

Fits dQ/dx profile only at the hits with the top two largest charge.

Adds a function to lookup if a 3D position overlaps with a disabled pixel or not.